### PR TITLE
Fix @PAGE & @PAGEOFF matching bug

### DIFF
--- a/syntax/arm64asm.vim
+++ b/syntax/arm64asm.vim
@@ -328,6 +328,7 @@ highlight default link AArch64PState     AArch64Register
 highlight default link AArch64SystemRegister AArch64Register
 highlight default link AArch64Type       Tag
 highlight default link AArch64TODO       Todo
+
 highlight default link AArch64String     String
 
 let b:current_syntax = "arm64asm"

--- a/syntax/arm64asm.vim
+++ b/syntax/arm64asm.vim
@@ -86,8 +86,8 @@ syntax match AArch64Modifier /:gottprel_lo12:/ contained
 syntax match AArch64Modifier /:gottprel_g1:/ contained
 syntax match AArch64Modifier /:gottprel_g0_nc:/ contained
 
-syntax match AArch64Modifier /@PAGE/ contained
-syntax match AArch64Modifier /@PAGEOFF/ contained
+syntax match AArch64Modifier /@PAGE/
+syntax match AArch64Modifier /@PAGEOFF/
 
 syntax match AArch64Identifier /[-_$.A-Za-z0-9]\+/
 syntax match AArch64Identifier /:.*:[-_$.A-Za-z0-9]\+/ contains=AArch64Modifier

--- a/syntax/arm64asm.vim
+++ b/syntax/arm64asm.vim
@@ -30,8 +30,9 @@ syntax case ignore
 syntax region AArch64Comment start="//" end="$" keepend contains=AArch64Special
 syntax region AArch64Comment start="/\*" end="\*/" contains=AArch64Special
 " MachO uses ; as a comment leader
-syntax region AArch64Comment start=";" end="$" contains=todo
+syntax region AArch64Comment start=";" end="$" contains=AArch64Special
 
+syntax keyword AArch64Directive .asciz .ascii .space
 syntax keyword AArch64Directive .align .p2align
 syntax keyword AArch64Directive .global .globl .type
 syntax keyword AArch64Directive .hword .word .xword .long .quad
@@ -102,6 +103,7 @@ syntax match AArch64Label /^[-_$.A-Za-z0-9]\+\s*:/
 " MachO uses L for the PrivateGloablPrefix, ELF uses .L
 syntax match AArch64Label /^\.\?L[-_$.A-Za-z0-9]\+\s*:/
 syntax match AArch64Label /^"[-_$.A-Za-z0-9 ]\+\s*":/
+syntax match AArch64String /"[^"]*"/
 
 syntax keyword AArch64Mnemonic ADC ADCS ADD ADDS ADR ADRP AND ANDS ASR ASRV AT
 
@@ -222,6 +224,8 @@ syntax keyword AArch64Mnemonic XTN XTN2
 
 syntax keyword AArch64Mnemonic ZIP1 ZIP2
 
+syntax match AArch64Mnemonic "\<[a-z]\+\(\.[0-9]*[bhdqsv]\)\>"
+
 syntax match AArch64Macro  /#[_a-zA-Z][_a-zA-Z0-9]*/
 
 syntax match AArch64Number /#-\?\d\+/
@@ -324,6 +328,6 @@ highlight default link AArch64PState     AArch64Register
 highlight default link AArch64SystemRegister AArch64Register
 highlight default link AArch64Type       Tag
 highlight default link AArch64TODO       Todo
+highlight default link AArch64String     String
 
 let b:current_syntax = "arm64asm"
-


### PR DESCRIPTION
`@PAGE` & `@PAGEOFF` weren't matching on identifiers beginning with the letter `l`.

There may be a better way to do this.